### PR TITLE
Documentation and Schedule Training Updates: 2019-Chicago

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If all else fails and Kitematic is not working for you, go to your `Terminal` or
 replacing <PATH_TO_TRAINING_FOLDERS> bit with the absolute path to
 "main directory" that was transferred from the flash/hard drive.
 ```
-docker run -it --rm --mount type=volume,dst=/home/rstudio/kitematic,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=<PATH_TO_TRAINING_FOLDERS> -e PASSWORD=<PASSWORD> -p 8787:8787
+docker run -it --rm --mount type=volume,dst=/home/rstudio/kitematic,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=<PATH_TO_TRAINING_FOLDERS> -e PASSWORD=<PASSWORD> -p 8787:8787 ccdl/training_rnaseq:2019-chicago
 ```
 After starting your container this way, you can get to the RStudio window in
 a similar way as described above:

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Here is the [schedule](schedule.md) for the workshop.
 
   In your respective command line interface, copy and paste the following:
 ```
-docker pull ccdl/training_rnaseq:2019-houston
+docker pull ccdl/training_rnaseq:2019-chicago
 ```
 
 2. Run the container. Change the `<PASSWORD>` in the line below to whatever you'd
   like.
 ```
-docker run -e PASSWORD=<PASSWORD> -p 8787:8787 ccdl/training_rnaseq:2019-houston
+docker run -e PASSWORD=<PASSWORD> -p 8787:8787 ccdl/training_rnaseq:2019-chicago
 ```
 
 3. Open `Kitematic` - you should see an image running.

--- a/docker-load.md
+++ b/docker-load.md
@@ -84,7 +84,7 @@ You should see output like:
 
 ```
 REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
-ccdl/training_rnaseq               2019-chicago        19c5bb6657d3        3 days ago          4.82GB
+ccdl/training_rnaseq               2019-chicago        22f2b4f05051        3 days ago          5.28GB
 ```
 
 _Note that the created field may not match._

--- a/docker-load.md
+++ b/docker-load.md
@@ -1,7 +1,7 @@
 
 ## Loading Docker image from flash drives
 
-_2019 Houston Workshop_
+_2019 Chicago Workshop_
 
 ### Copy files from the flash drives
 
@@ -34,7 +34,7 @@ gunzip ccdl_training_rnaseq.tar.gz
 docker load -i ccdl_training_rnaseq.tar
 ```
 
-This will take a minute. 
+This will take a minute.
 
 5. When this step completes, check that it was successful with:
 
@@ -46,7 +46,7 @@ You should see output like:
 
 ```
 REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
-ccdl/training_rnaseq               2019-houston        19c5bb6657d3        3 days ago          4.82GB
+ccdl/training_rnaseq               2019-chicago        22f2b4f05051        3 days ago          5.28GB
 ```
 
 _Note that the created field may not match._
@@ -57,22 +57,22 @@ Make sure you have 7-Zip installed.
 If you do not, you can download the `64-bit x64` program here: https://www.7-zip.org/
 
 1. Right-click `ccdl_training_rnaseq.tar.gz`.
-2. Go to `7-Zip` and selected `Extract Here`. 
+2. Go to `7-Zip` and selected `Extract Here`.
 When that has finished extraction, you should see `ccdl_training_rnaseq.tar` on your Desktop.
 
 3. Open your `Command Prompt` application.
 4. Navigate to your `Desktop` directory with:
- 
+
 ```
 cd Desktop
-``` 
+```
 4. You can load the Docker image with `docker load`:
 
 ```
 docker load -i ccdl_training_rnaseq.tar
 ```
 
-This will take a minute. 
+This will take a minute.
 
 5. When this step completes, check that it was successful with:
 
@@ -84,7 +84,7 @@ You should see output like:
 
 ```
 REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
-ccdl/training_rnaseq               2019-houston        19c5bb6657d3        3 days ago          4.82GB
+ccdl/training_rnaseq               2019-chicago        19c5bb6657d3        3 days ago          4.82GB
 ```
 
 _Note that the created field may not match._

--- a/docker-load.md
+++ b/docker-load.md
@@ -66,7 +66,7 @@ When that has finished extraction, you should see `ccdl_training_rnaseq.tar` on 
 ```
 cd Desktop
 ```
-4. You can load the Docker image with `docker load`:
+5. You can load the Docker image with `docker load`:
 
 ```
 docker load -i ccdl_training_rnaseq.tar
@@ -74,7 +74,7 @@ docker load -i ccdl_training_rnaseq.tar
 
 This will take a minute.
 
-5. When this step completes, check that it was successful with:
+6. When this step completes, check that it was successful with:
 
 ```
 docker images
@@ -84,7 +84,7 @@ You should see output like:
 
 ```
 REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
-ccdl/training_rnaseq               2019-chicago        19c5bb6657d3        3 days ago          5.28GB
+ccdl/training_rnaseq               2019-chicago        19c5bb6657d3        3 days ago          4.82GB
 ```
 
 _Note that the created field may not match._

--- a/docker-load.md
+++ b/docker-load.md
@@ -84,7 +84,7 @@ You should see output like:
 
 ```
 REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
-ccdl/training_rnaseq               2019-chicago        19c5bb6657d3        3 days ago          4.82GB
+ccdl/training_rnaseq               2019-chicago        19c5bb6657d3        3 days ago          5.28GB
 ```
 
 _Note that the created field may not match._

--- a/schedule.md
+++ b/schedule.md
@@ -11,7 +11,7 @@ Dates: 6/24/2019-6/26/2019
 | 10:15   | [Introduction to R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_r.nb.html)                                |
 | 11:00   | [R Intermediate Topics (including tidyverse)](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_tidyverse.nb.html)      |
 | 11:45   | Introduction to Exercise: [Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
-| 12:00 PM     | Run Salmon for RNA-seq [Salmon and QC](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)            |
+| 12:00 PM     | Processing for Bulk RNA-seq: [QC, trim, and quant](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)            |
 | 12:30   | Lunch                                          |
 | 1:30      | Data Diagnostics w/ a Gastric Cancer Dataset [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) |
 | 3:00      | Break                                          |

--- a/schedule.md
+++ b/schedule.md
@@ -6,17 +6,17 @@
 | Time      | Topic                                          |
 |-----------|------------------------------------------------|
 | **Day 1** |                                                |
-| 9:00 AM   | Intro & Welcome: ([Install Docker](https://github.com/AlexsLemonade/training-modules/blob/master/docker-install/README.md), [Prepare the RNA-seq Environment](https://github.com/AlexsLemonade/RNA-Seq-Exercises/blob/master/README.md), Introduction to RStudio)
+| 9:00 AM   | Welcome & Getting Started: ([Install Docker](https://github.com/AlexsLemonade/training-modules/blob/master/docker-install/README.md), [Prepare the RNA-seq Environment](https://github.com/AlexsLemonade/RNA-Seq-Exercises/blob/master/README.md), Introduction to RStudio)
 | 10:00   | Break                                            |
 | 10:15   | [Introduction to R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_r.nb.html)                                |
 | 11:00   | [R Intermediate Topics (including tidyverse)](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_tidyverse.nb.html)      |
-| 11:45   | Introduction to Exercise: [Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
+| 11:45   | Exercise Introduction: [Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
 | 12:00 PM     | Processing for Bulk RNA-seq: [QC, trim, and quant](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)            |
 | 12:30   | Lunch                                          |
 | 1:30      | Data Diagnostics w/ a Gastric Cancer Dataset: [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) |
 | 3:00      | Break                                          |
 | 3:15   | Differential Expression Analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md), [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)               |
-| 4:45      | Introduction to Exercise: [Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)                                              |
+| 4:45      | Exercise Introduction: [Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)                                              |
 | 5:00      | End                                            |
 |           |                                                |
 | **Day 2** |                                                |
@@ -25,10 +25,10 @@
 | 10:30     | scRNA-seq II: [Processing 10X data from raw](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/02-tag-based_pre-processing_scRNA-seq.md)                 |
 | 12:30 PM  | Lunch                                          |
 | 2:00      | scRNA-seq III: [Dimensionality reduction](https://alexslemonade.github.io/training-modules/scRNA-seq/03-dimension_reduction_scRNA-seq.nb.html)                                  |
-| 2:45      | Introduction to Exercise: [scRNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/04-scrnaseq_exercise.Rmd)                                              |
+| 2:45      | Exercise Introduction: [scRNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/04-scrnaseq_exercise.Rmd)                                              |
 | 3:00      | Break                                          |
 | 3:30      | Machine Learning: [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html), [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html), [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html), [Differential PLIER LVs](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)  
-| 4:45      | Introduction to Exercise: [Machine Learning](https://github.com/AlexsLemonade/training-modules/blob/master/machine-learning/05-machine_learning_exercise.Rmd)                                            |
+| 4:45      | Exercise Introduction: [Machine Learning](https://github.com/AlexsLemonade/training-modules/blob/master/machine-learning/05-machine_learning_exercise.Rmd)                                            |
 | 5:00      | End                                           |
 | 6:00      | Dinner at [The Berghoff](https://www.theberghoff.com/the-berghoff-restaurant-menu)                                 |
 |           |                                                |
@@ -38,4 +38,4 @@
 | 2:00      | Presentations, interpretations, and discussion |
 | 3:30      | Break                                          |
 | 4:00      | Talk from CCDL data science team and wrap-up   |
-| 5:00     | Adjourn                                        |
+| 5:00      | Adjourn                                        |

--- a/schedule.md
+++ b/schedule.md
@@ -7,35 +7,35 @@ Dates: 6/24/2019-6/26/2019
 |-----------|------------------------------------------------|
 | ### Day 1 |                                                |
 | 9:00 AM   | Intro & Welcome ([Install Docker](https://github.com/AlexsLemonade/training-modules/blob/master/docker-install/README.md); [Prepare the RNA-seq Environment](https://github.com/AlexsLemonade/RNA-Seq-Exercises/blob/master/README.md), Introduction to RStudio)
-| 10:00   | Break                                            |
-| 10:15   | [Introduction to R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_r.nb.html)                                |
-| 11:00   | [R Intermediate Topics (including tidyverse)](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_tidyverse.nb.html)      |
-| 11:45   | Introduction to Exercise: [Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
+| 10:00 AM  | Break                                            |
+| 10:15 AM  | [Introduction to R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_r.nb.html)                                |
+| 11:00 AM  | [R Intermediate Topics (including tidyverse)](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_tidyverse.nb.html)      |
+| 11:45 AM  | Introduction to Exercise: [Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
 | 12:00 PM     | Run Salmon for RNA-seq [Salmon and QC](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)            |
 | 12:30 PM  | Lunch                                          |
-| 1:30      | Data Diagnostics w/ a Gastric Cancer Dataset [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) |
-| 3:00      | Break                                          |
-| 3:15   | Differential Expression Analysis [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md), [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)               |
-| 4:45      | Introduction to Exercise: [Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/RNA-seq/06-bulk_rnaseq_exercise.Rmd)                                              |
-| 5:00      | End                                            |
+| 1:30 PM     | Data Diagnostics w/ a Gastric Cancer Dataset [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) |
+| 3:00 PM     | Break                                          |
+| 3:15 PM  | Differential Expression Analysis [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md), [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)               |
+| 4:45 PM     | Introduction to Exercise: [Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)                                              |
+| 5:00 PM     | End                                            |
 |           |                                                |
 | ### Day 2 |                                                |
-| 9:00     | scRNA-seq I: [Normalizing a count matrix](https://alexslemonade.github.io/training-modules/scRNA-seq/01-normalizing_scRNA-seq.nb.html)             |
+| 9:00 AM    | scRNA-seq I: [Normalizing a count matrix](https://alexslemonade.github.io/training-modules/scRNA-seq/01-normalizing_scRNA-seq.nb.html)             |
 | 10:15 AM  | Break                                          |
-| 10:30     | scRNA-seq II [Processing 10X data from raw](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/02-tag-based_pre-processing_scRNA-seq.md)                 |
+| 10:30 AM    | scRNA-seq II [Processing 10X data from raw](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/02-tag-based_pre-processing_scRNA-seq.md)                 |
 | 12:30 PM  | Lunch                                          |
-| 2:00      | scRNA-seq III: [Dimensionality reduction](https://alexslemonade.github.io/training-modules/scRNA-seq/03-dimension_reduction_scRNA-seq.nb.html)                                  |
-| 2:45      | Introduction to Exercise: [scRNA-seq](https://github.com/AlexsLemonade/training-modules/scRNA-seq/04-scrnaseq_exercise.Rmd)                                              |
-| 3:00      | Break                                          |
-| 3:30      | Machine Learning [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html), [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html), [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html), [Differential PLIER LVs](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)  
-| 4:45      | Introduction to Exercise: [Machine Learning](https://github.com/AlexsLemonade/training-modules/machine-learning/05-machine_learning_exercise.Rmd)                                            |
-| 5:00      | End                                           |
-| 6:00      | Dinner at [The Berghoff](https://www.theberghoff.com/the-berghoff-restaurant-menu)                                 |
+| 2:00 PM     | scRNA-seq III: [Dimensionality reduction](https://alexslemonade.github.io/training-modules/scRNA-seq/03-dimension_reduction_scRNA-seq.nb.html)                                  |
+| 2:45 PM     | Introduction to Exercise: [scRNA-seq](https://github.com/AlexsLemonade/training-modules/scRNA-seq/04-scrnaseq_exercise.Rmd)                                              |
+| 3:00 PM     | Break                                          |
+| 3:30 PM     | Machine Learning [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html), [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html), [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html), [Differential PLIER LVs](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)  
+| 4:45 PM     | Introduction to Exercise: [Machine Learning](https://github.com/AlexsLemonade/training-modules/machine-learning/05-machine_learning_exercise.Rmd)                                            |
+| 5:00 PM     | End                                           |
+| 6:00 PM     | Dinner at [The Berghoff](https://www.theberghoff.com/the-berghoff-restaurant-menu)                                 |
 |           |                                                |
 | ### Day 3 |                                                |
 | 9:00 AM   | Analyze your own data (or some stuff we have)!                         |
 | 12:30 PM  | Lunch                                          |
-| 2:00      | Presentations, interpretations, and discussion |
-| 3:30      | Break                                          |
-| 4:00      | Talk from CCDL data science team and wrap-up   |
-| 5:00      | Adjourn                                        |
+| 2:00 PM     | Presentations, interpretations, and discussion |
+| 3:30 PM     | Break                                          |
+| 4:00 PM     | Talk from CCDL data science team and wrap-up   |
+| 5:00 PM    | Adjourn                                        |

--- a/schedule.md
+++ b/schedule.md
@@ -3,39 +3,39 @@
 **Location**: 1 N Upper Wacker Dr, Chicago, Illinois 60606  
 **Dates**: 6/24/2019 - 6/26/2019
 
-| Time      | Topic                                          |
-|-----------|------------------------------------------------|
-| **Day 1** |                                                |
-| 9:00 AM   | Welcome & Getting Started: ([Install Docker](https://github.com/AlexsLemonade/training-modules/blob/master/docker-install/README.md), [Prepare the RNA-seq Environment](https://github.com/AlexsLemonade/RNA-Seq-Exercises/blob/master/README.md), Introduction to RStudio)
-| 10:00   | Break                                            |
-| 10:15   | [Introduction to R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_r.nb.html)                                |
-| 11:00   | [R Intermediate Topics (including tidyverse)](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_tidyverse.nb.html)      |
-| 11:45   | Exercise Introduction: [Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
-| 12:00 PM     | Processing for Bulk RNA-seq: [QC, trim, and quant](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)            |
-| 12:30   | Lunch                                          |
-| 1:30      | Data Diagnostics w/ a Gastric Cancer Dataset: [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) |
-| 3:00      | Break                                          |
-| 3:15   | Differential Expression Analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md), [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)               |
-| 4:45      | Exercise Introduction: [Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)                                              |
-| 5:00      | End                                            |
-|           |                                                |
-| **Day 2** |                                                |
-| 9:00 AM    | scRNA-seq I: [Normalizing a count matrix](https://alexslemonade.github.io/training-modules/scRNA-seq/01-normalizing_scRNA-seq.nb.html)             |
-| 10:15   | Break                                          |
-| 10:30     | scRNA-seq II: [Processing 10X data from raw](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/02-tag-based_pre-processing_scRNA-seq.md)                 |
-| 12:30 PM  | Lunch                                          |
-| 2:00      | scRNA-seq III: [Dimensionality reduction](https://alexslemonade.github.io/training-modules/scRNA-seq/03-dimension_reduction_scRNA-seq.nb.html)                                  |
-| 2:45      | Exercise Introduction: [scRNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/04-scrnaseq_exercise.Rmd)                                              |
-| 3:00      | Break                                          |
-| 3:30      | Machine Learning: [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html), [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html), [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html), [Differential PLIER LVs](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)  
-| 4:45      | Exercise Introduction: [Machine Learning](https://github.com/AlexsLemonade/training-modules/blob/master/machine-learning/05-machine_learning_exercise.Rmd)                                            |
-| 5:00      | End                                           |
-| 6:00      | Dinner at [The Berghoff](https://www.theberghoff.com/the-berghoff-restaurant-menu)                                 |
-|           |                                                |
-| **Day 3** |                                                |
-| 9:00 AM   | Analyze your own data (or some stuff we have)!                         |
-| 12:30 PM  | Lunch                                          |
-| 2:00      | Presentations, interpretations, and discussion |
-| 3:30      | Break                                          |
-| 4:00      | Talk from CCDL data science team and wrap-up   |
-| 5:00      | Adjourn                                        |
+| Time        | Topic                                          |
+|-------------|------------------------------------------------|
+| **Day 1**   |                                                |
+| 9:00 AM     | Welcome & Getting Started: ([Install Docker](https://github.com/AlexsLemonade/training-modules/blob/master/docker-install/README.md), [Prepare the RNA-seq Environment](https://github.com/AlexsLemonade/RNA-Seq-Exercises/blob/master/README.md), Introduction to RStudio)
+| 10:00       | Break                                            |
+| 10:15       | [Introduction to R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_r.nb.html)                                |
+| 11:00       | [R Intermediate Topics (including tidyverse)](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_tidyverse.nb.html)      |
+| 11:45       | Exercise Introduction: [Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
+| 12:00 PM    | Processing for Bulk RNA-seq: [QC, trim, and quant](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)            |
+| 12:30       | Lunch                                          |
+| 1:30        | Data Diagnostics w/ a Gastric Cancer Dataset: [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) |
+| 3:00        | Break                                          |
+| 3:15        | Differential Expression Analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md), [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)               |
+| 4:45        | Exercise Introduction: [Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)                                              |
+| 5:00        | End                                            |
+|             |                                                |
+| **Day 2**   |                                                |
+| 9:00 AM     | scRNA-seq I: [Normalizing a count matrix](https://alexslemonade.github.io/training-modules/scRNA-seq/01-normalizing_scRNA-seq.nb.html)             |
+| 10:15       | Break                                          |
+| 10:30       | scRNA-seq II: [Processing 10X data from raw](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/02-tag-based_pre-processing_scRNA-seq.md)                 |
+| 12:30 PM    | Lunch                                          |
+| 2:00        | scRNA-seq III: [Dimensionality reduction](https://alexslemonade.github.io/training-modules/scRNA-seq/03-dimension_reduction_scRNA-seq.nb.html)                                  |
+| 2:45        | Exercise Introduction: [scRNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/04-scrnaseq_exercise.Rmd)                                              |
+| 3:00        | Break                                          |
+| 3:30        | Machine Learning: [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html), [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html), [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html), [Differential PLIER LVs](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)  
+| 4:45        | Exercise Introduction: [Machine Learning](https://github.com/AlexsLemonade/training-modules/blob/master/machine-learning/05-machine_learning_exercise.Rmd)                                            |
+| 5:00        | End                                           |
+| 6:00        | Dinner at [The Berghoff](https://www.theberghoff.com/the-berghoff-restaurant-menu)                                 |
+|             |                                                |
+| **Day 3**   |                                                |
+| 9:00 AM     | Analyze your own data (or some stuff we have)!                         |
+| 12:30 PM    | Lunch                                          |
+| 2:00        | Presentations, interpretations, and discussion |
+| 3:30        | Break                                          |
+| 4:00        | Talk from CCDL data science team and wrap-up   |
+| 5:00        | Adjourn                                        |

--- a/schedule.md
+++ b/schedule.md
@@ -1,38 +1,38 @@
 ## Chicago CCDL Training
 
-Location: 1 N Upper Wacker Dr, Chicago, Illinois 60606  
-Dates: 6/24/2019-6/26/2019
+**Location**: 1 N Upper Wacker Dr, Chicago, Illinois 60606  
+**Dates**: 6/24/2019 - 6/26/2019
 
 | Time      | Topic                                          |
 |-----------|------------------------------------------------|
-| ### Day 1 |                                                |
-| 9:00 AM   | Intro & Welcome ([Install Docker](https://github.com/AlexsLemonade/training-modules/blob/master/docker-install/README.md); [Prepare the RNA-seq Environment](https://github.com/AlexsLemonade/RNA-Seq-Exercises/blob/master/README.md), Introduction to RStudio)
+| **Day 1** |                                                |
+| 9:00 AM   | Intro & Welcome: ([Install Docker](https://github.com/AlexsLemonade/training-modules/blob/master/docker-install/README.md), [Prepare the RNA-seq Environment](https://github.com/AlexsLemonade/RNA-Seq-Exercises/blob/master/README.md), Introduction to RStudio)
 | 10:00   | Break                                            |
 | 10:15   | [Introduction to R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_r.nb.html)                                |
 | 11:00   | [R Intermediate Topics (including tidyverse)](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_tidyverse.nb.html)      |
 | 11:45   | Introduction to Exercise: [Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
 | 12:00 PM     | Processing for Bulk RNA-seq: [QC, trim, and quant](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)            |
 | 12:30   | Lunch                                          |
-| 1:30      | Data Diagnostics w/ a Gastric Cancer Dataset [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) |
+| 1:30      | Data Diagnostics w/ a Gastric Cancer Dataset: [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) |
 | 3:00      | Break                                          |
-| 3:15   | Differential Expression Analysis [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md), [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)               |
+| 3:15   | Differential Expression Analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md), [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)               |
 | 4:45      | Introduction to Exercise: [Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)                                              |
 | 5:00      | End                                            |
 |           |                                                |
-| ### Day 2 |                                                |
+| **Day 2** |                                                |
 | 9:00 AM    | scRNA-seq I: [Normalizing a count matrix](https://alexslemonade.github.io/training-modules/scRNA-seq/01-normalizing_scRNA-seq.nb.html)             |
 | 10:15   | Break                                          |
-| 10:30     | scRNA-seq II [Processing 10X data from raw](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/02-tag-based_pre-processing_scRNA-seq.md)                 |
+| 10:30     | scRNA-seq II: [Processing 10X data from raw](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/02-tag-based_pre-processing_scRNA-seq.md)                 |
 | 12:30 PM  | Lunch                                          |
 | 2:00      | scRNA-seq III: [Dimensionality reduction](https://alexslemonade.github.io/training-modules/scRNA-seq/03-dimension_reduction_scRNA-seq.nb.html)                                  |
 | 2:45      | Introduction to Exercise: [scRNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/04-scrnaseq_exercise.Rmd)                                              |
 | 3:00      | Break                                          |
-| 3:30      | Machine Learning [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html), [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html), [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html), [Differential PLIER LVs](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)  
+| 3:30      | Machine Learning: [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html), [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html), [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html), [Differential PLIER LVs](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)  
 | 4:45      | Introduction to Exercise: [Machine Learning](https://github.com/AlexsLemonade/training-modules/blob/master/machine-learning/05-machine_learning_exercise.Rmd)                                            |
 | 5:00      | End                                           |
 | 6:00      | Dinner at [The Berghoff](https://www.theberghoff.com/the-berghoff-restaurant-menu)                                 |
 |           |                                                |
-| ### Day 3 |                                                |
+| **Day 3** |                                                |
 | 9:00 AM   | Analyze your own data (or some stuff we have)!                         |
 | 12:30 PM  | Lunch                                          |
 | 2:00      | Presentations, interpretations, and discussion |

--- a/schedule.md
+++ b/schedule.md
@@ -7,35 +7,35 @@ Dates: 6/24/2019-6/26/2019
 |-----------|------------------------------------------------|
 | ### Day 1 |                                                |
 | 9:00 AM   | Intro & Welcome ([Install Docker](https://github.com/AlexsLemonade/training-modules/blob/master/docker-install/README.md); [Prepare the RNA-seq Environment](https://github.com/AlexsLemonade/RNA-Seq-Exercises/blob/master/README.md), Introduction to RStudio)
-| 10:00 AM  | Break                                            |
-| 10:15 AM  | [Introduction to R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_r.nb.html)                                |
-| 11:00 AM  | [R Intermediate Topics (including tidyverse)](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_tidyverse.nb.html)      |
-| 11:45 AM  | Introduction to Exercise: [Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
+| 10:00   | Break                                            |
+| 10:15   | [Introduction to R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_r.nb.html)                                |
+| 11:00   | [R Intermediate Topics (including tidyverse)](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_tidyverse.nb.html)      |
+| 11:45   | Introduction to Exercise: [Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
 | 12:00 PM     | Run Salmon for RNA-seq [Salmon and QC](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)            |
-| 12:30 PM  | Lunch                                          |
-| 1:30 PM     | Data Diagnostics w/ a Gastric Cancer Dataset [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) |
-| 3:00 PM     | Break                                          |
-| 3:15 PM  | Differential Expression Analysis [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md), [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)               |
-| 4:45 PM     | Introduction to Exercise: [Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)                                              |
-| 5:00 PM     | End                                            |
+| 12:30   | Lunch                                          |
+| 1:30      | Data Diagnostics w/ a Gastric Cancer Dataset [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) |
+| 3:00      | Break                                          |
+| 3:15   | Differential Expression Analysis [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md), [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)               |
+| 4:45      | Introduction to Exercise: [Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)                                              |
+| 5:00      | End                                            |
 |           |                                                |
 | ### Day 2 |                                                |
 | 9:00 AM    | scRNA-seq I: [Normalizing a count matrix](https://alexslemonade.github.io/training-modules/scRNA-seq/01-normalizing_scRNA-seq.nb.html)             |
-| 10:15 AM  | Break                                          |
-| 10:30 AM    | scRNA-seq II [Processing 10X data from raw](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/02-tag-based_pre-processing_scRNA-seq.md)                 |
+| 10:15   | Break                                          |
+| 10:30     | scRNA-seq II [Processing 10X data from raw](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/02-tag-based_pre-processing_scRNA-seq.md)                 |
 | 12:30 PM  | Lunch                                          |
-| 2:00 PM     | scRNA-seq III: [Dimensionality reduction](https://alexslemonade.github.io/training-modules/scRNA-seq/03-dimension_reduction_scRNA-seq.nb.html)                                  |
-| 2:45 PM     | Introduction to Exercise: [scRNA-seq](https://github.com/AlexsLemonade/training-modules/scRNA-seq/04-scrnaseq_exercise.Rmd)                                              |
-| 3:00 PM     | Break                                          |
-| 3:30 PM     | Machine Learning [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html), [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html), [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html), [Differential PLIER LVs](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)  
-| 4:45 PM     | Introduction to Exercise: [Machine Learning](https://github.com/AlexsLemonade/training-modules/machine-learning/05-machine_learning_exercise.Rmd)                                            |
-| 5:00 PM     | End                                           |
-| 6:00 PM     | Dinner at [The Berghoff](https://www.theberghoff.com/the-berghoff-restaurant-menu)                                 |
+| 2:00      | scRNA-seq III: [Dimensionality reduction](https://alexslemonade.github.io/training-modules/scRNA-seq/03-dimension_reduction_scRNA-seq.nb.html)                                  |
+| 2:45      | Introduction to Exercise: [scRNA-seq](https://github.com/AlexsLemonade/training-modules/scRNA-seq/04-scrnaseq_exercise.Rmd)                                              |
+| 3:00      | Break                                          |
+| 3:30      | Machine Learning [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html), [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html), [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html), [Differential PLIER LVs](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)  
+| 4:45      | Introduction to Exercise: [Machine Learning](https://github.com/AlexsLemonade/training-modules/machine-learning/05-machine_learning_exercise.Rmd)                                            |
+| 5:00      | End                                           |
+| 6:00      | Dinner at [The Berghoff](https://www.theberghoff.com/the-berghoff-restaurant-menu)                                 |
 |           |                                                |
 | ### Day 3 |                                                |
 | 9:00 AM   | Analyze your own data (or some stuff we have)!                         |
 | 12:30 PM  | Lunch                                          |
-| 2:00 PM     | Presentations, interpretations, and discussion |
-| 3:30 PM     | Break                                          |
-| 4:00 PM     | Talk from CCDL data science team and wrap-up   |
-| 5:00 PM    | Adjourn                                        |
+| 2:00      | Presentations, interpretations, and discussion |
+| 3:30      | Break                                          |
+| 4:00      | Talk from CCDL data science team and wrap-up   |
+| 5:00     | Adjourn                                        |

--- a/schedule.md
+++ b/schedule.md
@@ -10,7 +10,7 @@ Dates: 6/24/2019-6/26/2019
 | 10:00   | Break                                            |
 | 10:15   | [Introduction to R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_r.nb.html)                                |
 | 11:00   | [R Intermediate Topics (including tidyverse)](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_tidyverse.nb.html)      |
-| 11:45   | Introduction to Exercise: [Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
+| 11:45   | Introduction to Exercise: [Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
 | 12:00 PM     | Processing for Bulk RNA-seq: [QC, trim, and quant](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)            |
 | 12:30   | Lunch                                          |
 | 1:30      | Data Diagnostics w/ a Gastric Cancer Dataset [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) |
@@ -25,10 +25,10 @@ Dates: 6/24/2019-6/26/2019
 | 10:30     | scRNA-seq II [Processing 10X data from raw](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/02-tag-based_pre-processing_scRNA-seq.md)                 |
 | 12:30 PM  | Lunch                                          |
 | 2:00      | scRNA-seq III: [Dimensionality reduction](https://alexslemonade.github.io/training-modules/scRNA-seq/03-dimension_reduction_scRNA-seq.nb.html)                                  |
-| 2:45      | Introduction to Exercise: [scRNA-seq](https://github.com/AlexsLemonade/training-modules/scRNA-seq/04-scrnaseq_exercise.Rmd)                                              |
+| 2:45      | Introduction to Exercise: [scRNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/04-scrnaseq_exercise.Rmd)                                              |
 | 3:00      | Break                                          |
 | 3:30      | Machine Learning [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html), [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html), [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html), [Differential PLIER LVs](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)  
-| 4:45      | Introduction to Exercise: [Machine Learning](https://github.com/AlexsLemonade/training-modules/machine-learning/05-machine_learning_exercise.Rmd)                                            |
+| 4:45      | Introduction to Exercise: [Machine Learning](https://github.com/AlexsLemonade/training-modules/blob/master/machine-learning/05-machine_learning_exercise.Rmd)                                            |
 | 5:00      | End                                           |
 | 6:00      | Dinner at [The Berghoff](https://www.theberghoff.com/the-berghoff-restaurant-menu)                                 |
 |           |                                                |

--- a/schedule.md
+++ b/schedule.md
@@ -10,13 +10,13 @@ Dates: 6/24/2019-6/26/2019
 | 10:00   | Break                                            |
 | 10:15   | [Introduction to R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_r.nb.html)                                |
 | 11:00   | [R Intermediate Topics (including tidyverse)](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_tidyverse.nb.html)      |
-| 11:45   | [Exercise: Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
-| 12:00 PM  | Lunch                                          |
-| 1:00      | Run Salmon for RNA-seq [Salmon and QC](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-download_qc_quant.md), [Shell scripting for reproducibility](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/02-reproducibility_cmdline.md)            |
-| 2:00      | Data Diagnostics w/ a Gastric Cancer Dataset [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/04-gastric_cancer_exploratory.nb.html) |
-| 3:30      | Break                                          |
-| 4:00   | Differential Expression Analysis [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/05-nb_cell_line_tximport.md), [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/06-nb_cell_line_DESeq2.nb.html)               |
-| 4:45      | [Exercise: Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/RNA-seq/07-bulk_rnaseq_exercise.Rmd)                                              |
+| 11:45   | Introduction to Exercise: [Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
+| 12:00 PM     | Run Salmon for RNA-seq [Salmon and QC](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)            |
+| 12:30 PM  | Lunch                                          |
+| 1:30      | Data Diagnostics w/ a Gastric Cancer Dataset [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) |
+| 3:00      | Break                                          |
+| 3:15   | Differential Expression Analysis [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md), [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)               |
+| 4:45      | Introduction to Exercise: [Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/RNA-seq/06-bulk_rnaseq_exercise.Rmd)                                              |
 | 5:00      | End                                            |
 |           |                                                |
 | ### Day 2 |                                                |
@@ -25,10 +25,10 @@ Dates: 6/24/2019-6/26/2019
 | 10:30     | scRNA-seq II [Processing 10X data from raw](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/02-tag-based_pre-processing_scRNA-seq.md)                 |
 | 12:30 PM  | Lunch                                          |
 | 2:00      | scRNA-seq III: [Dimensionality reduction](https://alexslemonade.github.io/training-modules/scRNA-seq/03-dimension_reduction_scRNA-seq.nb.html)                                  |
-| 2:45      | [Exercise: scRNA-seq](https://github.com/AlexsLemonade/training-modules/scRNA-seq/04-scrnaseq_exercise.Rmd)                                              |
+| 2:45      | Introduction to Exercise: [scRNA-seq](https://github.com/AlexsLemonade/training-modules/scRNA-seq/04-scrnaseq_exercise.Rmd)                                              |
 | 3:00      | Break                                          |
 | 3:30      | Machine Learning [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html), [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html), [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html), [Differential PLIER LVs](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)  
-| 4:45      | [Exercise: Machine Learning](https://github.com/AlexsLemonade/training-modules/machine-learning/05-machine_learning_exercise.Rmd)                                            |
+| 4:45      | Introduction to Exercise: [Machine Learning](https://github.com/AlexsLemonade/training-modules/machine-learning/05-machine_learning_exercise.Rmd)                                            |
 | 5:00      | End                                           |
 | 6:00      | Dinner at [The Berghoff](https://www.theberghoff.com/the-berghoff-restaurant-menu)                                 |
 |           |                                                |

--- a/schedule.md
+++ b/schedule.md
@@ -10,11 +10,13 @@ Dates: 6/24/2019-6/26/2019
 | 10:00   | Break                                            |
 | 10:15   | [Introduction to R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_r.nb.html)                                |
 | 11:00   | [R Intermediate Topics (including tidyverse)](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_tidyverse.nb.html)      |
+| 11:45   | [Exercise: Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
 | 12:00 PM  | Lunch                                          |
 | 1:00      | Run Salmon for RNA-seq [Salmon and QC](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-download_qc_quant.md), [Shell scripting for reproducibility](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/02-reproducibility_cmdline.md)            |
 | 2:00      | Data Diagnostics w/ a Gastric Cancer Dataset [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/04-gastric_cancer_exploratory.nb.html) |
 | 3:30      | Break                                          |
 | 4:00   | Differential Expression Analysis [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/05-nb_cell_line_tximport.md), [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/06-nb_cell_line_DESeq2.nb.html)               |
+| 4:45      | [Exercise: Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/RNA-seq/07-bulk_rnaseq_exercise.Rmd)                                              |
 | 5:00      | End                                            |
 |           |                                                |
 | ### Day 2 |                                                |
@@ -23,10 +25,12 @@ Dates: 6/24/2019-6/26/2019
 | 10:30     | scRNA-seq II [Processing 10X data from raw](https://github.com/AlexsLemonade/training-modules/blob/master/scRNA-seq/02-tag-based_pre-processing_scRNA-seq.md)                 |
 | 12:30 PM  | Lunch                                          |
 | 2:00      | scRNA-seq III: [Dimensionality reduction](https://alexslemonade.github.io/training-modules/scRNA-seq/03-dimension_reduction_scRNA-seq.nb.html)                                  |
+| 2:45      | [Exercise: scRNA-seq](https://github.com/AlexsLemonade/training-modules/scRNA-seq/04-scrnaseq_exercise.Rmd)                                              |
 | 3:00      | Break                                          |
 | 3:30      | Machine Learning [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html), [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html), [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html), [Differential PLIER LVs](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)  
-| 5:00      | End                                            |
-| 6:00      | Dinner at TBD                                  |
+| 4:45      | [Exercise: Machine Learning](https://github.com/AlexsLemonade/training-modules/machine-learning/05-machine_learning_exercise.Rmd)                                            |
+| 5:00      | End                                           |
+| 6:00      | Dinner at [The Berghoff](https://www.theberghoff.com/the-berghoff-restaurant-menu)                                 |
 |           |                                                |
 | ### Day 3 |                                                |
 | 9:00 AM   | Analyze your own data (or some stuff we have)!                         |


### PR DESCRIPTION
Now that the [Salmon version issue](https://github.com/AlexsLemonade/training-modules/issues/70) has been temporarily settled, and the newest training docker image has been pushed: `ccdl/training_rnaseq:2019-chicago`; This PR addresses the issues #34 and #37 in this repository. 

Last thing we need to hammer out is what the exact file name will be for the machine-learning exercise notebook. I temporarily put what I think should be its url, based on following convention, however, we shouldn't merge this until that is finalized. 