### PR TITLE
Added code of conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -5,7 +5,7 @@ We value the involvement of everyone in the community. We are committed to creat
 
 To make clear what is expected, everyone participating in Childhood Cancer Data Lab (CCDL) training activities are required to conform to the Code of Conduct. This Code of Conduct applies to all spaces managed by the CCDL including, but not limited to, training workshops, email lists, and online forums such as GitHub, Slack and Twitter.
 
-If you at any time feel harassed or treated inappropriately please contact ccdl@alexslemonade.org.
+If you at any time feel harassed or treated inappropriately, please contact ccdl@alexslemonade.org.
 
 
 ## Code of Conduct

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -72,7 +72,7 @@ Examples of unacceptable behavior by participants at any CCDL training event/pla
 
 - publication of private communication without consent
 
-If you at any time feel harassed or treated inappropriately, please contact ccdl@alexslemonade.org.
+If you at any time feel harassed or treated inappropriately, please contact [ccdl@alexslemonade.org](ccdl@alexslemonade.org).
 
 ### Consequences of Unacceptable behavior
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,22 +1,34 @@
 # Code of Conduct
 
 ## Summary
-We value the involvement of everyone in the community. We are committed to creating a friendly and respectful place for learning, teaching, and contributing. All participants in our events and communications are expected to show respect and courtesy to others.
 
-To make clear what is expected, everyone participating in Childhood Cancer Data Lab (CCDL) training activities are required to conform to the Code of Conduct. This Code of Conduct applies to all spaces managed by the CCDL including, but not limited to, training workshops, email lists, and online forums such as GitHub, Slack and Twitter.
+We value the involvement of everyone in the community.
+We are committed to creating a friendly and respectful place for learning, teaching, and contributing.
 
-If you at any time feel harassed or treated inappropriately, please contact ccdl@alexslemonade.org.
+All participants in our events and communications are expected to show respect and courtesy to others.
+
+To make clear what is expected, everyone participating in Childhood Cancer Data Lab (CCDL) training activities are required to conform to the Code of Conduct.
+This Code of Conduct applies to all spaces managed by the CCDL including, but not limited to, training workshops, email lists, and online forums such as GitHub, Slack and Twitter.
+
+If you at any time feel harassed or treated inappropriately, please contact [ccdl@alexslemonade.org](mailto:ccdl@alexslemonade.org).
 
 
 ## Code of Conduct
 
-The CCDL team is dedicated to providing a welcoming and supportive environment for all people, regardless of background or identity. As such, we do not tolerate behavior that is disrespectful to our teachers or learners or that excludes, intimidates, or causes discomfort to others. We do not tolerate discrimination or harassment based on characteristics that include, but are not limited to, gender identity and expression, sexual orientation, disability, physical appearance, body size, citizenship, nationality, ethnic or social origin, pregnancy, familial status, veteran status, genetic information, religion or belief (or lack thereof), membership of a national minority, property, age, education, socio-economic status, technical choices, and experience level.
+The CCDL team is dedicated to providing a welcoming and supportive environment for all people, regardless of background or identity.
+As such, we do not tolerate behavior that is disrespectful to our teachers or learners or that excludes, intimidates, or causes discomfort to others.
+We do not tolerate discrimination or harassment based on characteristics that include, but are not limited to, gender identity and expression, sexual orientation, disability, physical appearance, body size, citizenship, nationality, ethnic or social origin, pregnancy, familial status, veteran status, genetic information, religion or belief (or lack thereof), membership of a national minority, property, age, education, socio-economic status, technical choices, and experience level.
 
-Everyone who participates in CCDL training activities is required to conform to this Code of Conduct. It applies to all spaces managed by the CCDL including, but not limited to, training workshops, email lists, and online forums such as GitHub, Slack and Twitter. By participating, participants indicate their acceptance of the procedures by which the CCDL resolves any Code of Conduct incidents, which may include storage and processing of their personal information.
+Everyone who participates in CCDL training activities is required to conform to this Code of Conduct.
+It applies to all spaces managed by the CCDL including, but not limited to, training workshops, email lists, and online forums such as GitHub, Slack and Twitter.
+By participating, participants indicate their acceptance of the procedures by which the CCDL resolves any Code of Conduct incidents, which may include storage and processing of their personal information.
 
 ### Expected behavior
 
-All participants in our events and communications are expected to show respect and courtesy to others. All interactions should be professional regardless of platform: either online or in-person. In order to foster a positive and professional learning environment we encourage the following kinds of behaviors in all CCDL training events and platforms:
+All participants in our events and communications are expected to show respect and courtesy to others.
+All interactions should be professional regardless of platform: either online or in-person.
+
+In order to foster a positive and professional learning environment we encourage the following kinds of behaviors in all CCDL training events and platforms:
 
 - Use welcoming and inclusive language
 
@@ -60,11 +72,14 @@ Examples of unacceptable behavior by participants at any CCDL training event/pla
 
 - publication of private communication without consent
 
-If you at any time feel harassed or treated inappropriately please contact ccdl@alexslemonade.org.
+If you at any time feel harassed or treated inappropriately, please contact ccdl@alexslemonade.org.
 
 ### Consequences of Unacceptable behavior
 
-Participants who are asked to stop any inappropriate behavior are expected to comply immediately. This applies to any CCDL training events and platforms, either online or in-person. If a participant engages in behavior that violates this code of conduct, the organizers may warn the offender, ask them to leave the event or platform.
+Participants who are asked to stop any inappropriate behavior are expected to comply immediately.
+This applies to any CCDL training events and platforms, either online or in-person.
+If a participant engages in behavior that violates this code of conduct, the organizers may warn the offender, ask them to leave the event or platform.
 
 # License
-This document is based on the code of conduct written by [The Carpentries](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#code-of-conduct-detailed-view), which is adapted from the guidelines by the [Django Project](https://www.djangoproject.com/conduct/enforcement-manual/), which was itself based on the [Ada Initiative](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports) template. 
+
+This document is based on the code of conduct written by [The Carpentries](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#code-of-conduct-detailed-view), which is adapted from the guidelines by the [Django Project](https://www.djangoproject.com/conduct/enforcement-manual/), which was itself based on the [Ada Initiative](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports) template.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -72,7 +72,7 @@ Examples of unacceptable behavior by participants at any CCDL training event/pla
 
 - publication of private communication without consent
 
-If you at any time feel harassed or treated inappropriately, please contact [ccdl@alexslemonade.org](ccdl@alexslemonade.org).
+If you feel harassed or treated inappropriately at any time, please contact the Director of the CCDL at [ccdl@alexslemonade.org](mailto:ccdl@alexslemonade.org)
 
 ### Consequences of Unacceptable behavior
 
@@ -80,6 +80,6 @@ Participants who are asked to stop any inappropriate behavior are expected to co
 This applies to any CCDL training events and platforms, either online or in-person.
 If a participant engages in behavior that violates this code of conduct, the organizers may warn the offender or require them to leave the event or platform.
 
-# License
+# Source
 
 This document is based on the code of conduct written by [The Carpentries](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#code-of-conduct-detailed-view), which is adapted from the guidelines by the [Django Project](https://www.djangoproject.com/conduct/enforcement-manual/), which was itself based on the [Ada Initiative](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports) template.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -7,7 +7,7 @@ We are committed to creating a friendly and respectful place for learning, teach
 
 All participants in our events and communications are expected to show respect and courtesy to others.
 
-To make clear what is expected, everyone participating in Childhood Cancer Data Lab (CCDL) training activities are required to conform to the Code of Conduct.
+To make clear what is expected, everyone participating in Childhood Cancer Data Lab (CCDL) training activities is required to conform to the Code of Conduct.
 This Code of Conduct applies to all spaces managed by the CCDL including, but not limited to, training workshops, email lists, and online forums such as GitHub, Slack and Twitter.
 
 If you feel harassed or treated inappropriately at any time, please contact the Director of the CCDL at [ccdl@alexslemonade.org](mailto:ccdl@alexslemonade.org).

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,0 +1,70 @@
+# Code of Conduct
+
+## Summary
+We value the involvement of everyone in the community. We are committed to creating a friendly and respectful place for learning, teaching, and contributing. All participants in our events and communications are expected to show respect and courtesy to others.
+
+To make clear what is expected, everyone participating in Childhood Cancer Data Lab (CCDL) training activities are required to conform to the Code of Conduct. This Code of Conduct applies to all spaces managed by the CCDL including, but not limited to, training workshops, email lists, and online forums such as GitHub, Slack and Twitter.
+
+If you at any time feel harassed or treated inappropriately please contact ccdl@alexslemonade.org.
+
+
+## Code of Conduct
+
+The CCDL team is dedicated to providing a welcoming and supportive environment for all people, regardless of background or identity. As such, we do not tolerate behavior that is disrespectful to our teachers or learners or that excludes, intimidates, or causes discomfort to others. We do not tolerate discrimination or harassment based on characteristics that include, but are not limited to, gender identity and expression, sexual orientation, disability, physical appearance, body size, citizenship, nationality, ethnic or social origin, pregnancy, familial status, veteran status, genetic information, religion or belief (or lack thereof), membership of a national minority, property, age, education, socio-economic status, technical choices, and experience level.
+
+Everyone who participates in CCDL training activities is required to conform to this Code of Conduct. It applies to all spaces managed by the CCDL including, but not limited to, training workshops, email lists, and online forums such as GitHub, Slack and Twitter. By participating, participants indicate their acceptance of the procedures by which the CCDL resolves any Code of Conduct incidents, which may include storage and processing of their personal information.
+
+### Expected behavior
+
+All participants in our events and communications are expected to show respect and courtesy to others. All interactions should be professional regardless of platform: either online or in-person. In order to foster a positive and professional learning environment we encourage the following kinds of behaviors in all CCDL training events and platforms:
+
+- Use welcoming and inclusive language
+
+- Be respectful of different viewpoints and experiences
+
+- Gracefully accept constructive criticism
+
+- Focus on what is best for the community
+
+- Show courtesy and respect towards other community members
+
+Note: See the [four social rules](https://www.recurse.com/manual#sub-sec-social-rules) for further recommendations.
+
+### Unacceptable behavior
+
+Examples of unacceptable behavior by participants at any CCDL training event/platform include:
+
+- written or verbal comments which have the effect of excluding people on the basis of membership of any specific group
+
+- causing someone to fear for their safety, such as through stalking, following, or intimidation
+
+- violent threats or language directed against another person
+
+- the display of sexual or violent images
+
+- unwelcome sexual attention
+
+- nonconsensual or unwelcome physical contact
+
+- sustained disruption of talks, events or communications
+
+- insults or put downs
+
+- sexist, racist, homophobic, transphobic, ableist, or exclusionary jokes
+
+- excessive swearing
+
+- incitement to violence, suicide, or self-harm
+
+- continuing to initiate interaction (including photography or recording) with someone after being asked to stop
+
+- publication of private communication without consent
+
+If you at any time feel harassed or treated inappropriately please contact ccdl@alexslemonade.org.
+
+### Consequences of Unacceptable behavior
+
+Participants who are asked to stop any inappropriate behavior are expected to comply immediately. This applies to any CCDL training events and platforms, either online or in-person. If a participant engages in behavior that violates this code of conduct, the organizers may warn the offender, ask them to leave the event or platform.
+
+# License
+This document is based on the code of conduct written by [The Carpentries](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html#code-of-conduct-detailed-view), which is adapted from the guidelines by the [Django Project](https://www.djangoproject.com/conduct/enforcement-manual/), which was itself based on the [Ada Initiative](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports) template. 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -10,13 +10,13 @@ All participants in our events and communications are expected to show respect a
 To make clear what is expected, everyone participating in Childhood Cancer Data Lab (CCDL) training activities are required to conform to the Code of Conduct.
 This Code of Conduct applies to all spaces managed by the CCDL including, but not limited to, training workshops, email lists, and online forums such as GitHub, Slack and Twitter.
 
-If you at any time feel harassed or treated inappropriately, please contact [ccdl@alexslemonade.org](mailto:ccdl@alexslemonade.org).
+If you feel harassed or treated inappropriately at any time, please contact the Director of the CCDL at [ccdl@alexslemonade.org](mailto:ccdl@alexslemonade.org).
 
 
 ## Code of Conduct
 
 The CCDL team is dedicated to providing a welcoming and supportive environment for all people, regardless of background or identity.
-As such, we do not tolerate behavior that is disrespectful to our teachers or learners or that excludes, intimidates, or causes discomfort to others.
+As such, we do not tolerate behavior that is disrespectful to our learners or teachers or that excludes, intimidates, or causes discomfort to others.
 We do not tolerate discrimination or harassment based on characteristics that include, but are not limited to, gender identity and expression, sexual orientation, disability, physical appearance, body size, citizenship, nationality, ethnic or social origin, pregnancy, familial status, veteran status, genetic information, religion or belief (or lack thereof), membership of a national minority, property, age, education, socio-economic status, technical choices, and experience level.
 
 Everyone who participates in CCDL training activities is required to conform to this Code of Conduct.
@@ -78,7 +78,7 @@ If you at any time feel harassed or treated inappropriately, please contact [ccd
 
 Participants who are asked to stop any inappropriate behavior are expected to comply immediately.
 This applies to any CCDL training events and platforms, either online or in-person.
-If a participant engages in behavior that violates this code of conduct, the organizers may warn the offender, ask them to leave the event or platform.
+If a participant engages in behavior that violates this code of conduct, the organizers may warn the offender or require them to leave the event or platform.
 
 # License
 


### PR DESCRIPTION
It is heavily based off this: https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html
with the exception of how complaints are handled. (which for us, is email ccdl@alexslemonade.org)  