### PR TITLE
Schedule Updates - more time for R exercises

### DIFF
--- a/docker-load.md
+++ b/docker-load.md
@@ -53,7 +53,7 @@ You should see output like:
 
 ```
 REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
-ccdl/training_rnaseq               2019-czi        <TODO:IMAGE_ID>        3 days ago          5.28GB
+ccdl/training_rnaseq               2019-czi            16eb55269eec        19 minutes ago      5.03GB
 ```
 
 _Note that the created field may not match._
@@ -91,7 +91,7 @@ You should see output like:
 
 ```
 REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
-ccdl/training_rnaseq               2019-czi        <TODO:IMAGE_ID>        3 days ago          5.28GB
+ccdl/training_rnaseq               2019-czi            16eb55269eec        19 minutes ago      5.03GB
 ```
 _Note that the created field may not match._
 

--- a/schedule.md
+++ b/schedule.md
@@ -10,13 +10,14 @@
 | 9:10        | Getting Started: [Install Docker](https://github.com/AlexsLemonade/training-modules/blob/master/docker-install/README.md), [Get files from flash drives](flashdrive-instructions.md), [Docker container set up](docker-pull.md) |
 | 10:00       | Break                                            |
 | 10:15       | [Introduction to R](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/01-intro_to_r.nb.html)                                |
-| 11:00       | [R Intermediate Topics (including tidyverse)](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_tidyverse.nb.html)      |
-| 11:45       | Exercise Introduction: [Intro to R/Tidyverse](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/03-intro_to_r_tidyverse_exercise.Rmd)      |
-| 12:00 PM    | Processing for Bulk RNA-seq: [QC, trim, and quant](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)            |
+| 11:00       | [R Intermediate Topics (including Tidyverse)](https://alexslemonade.github.io/training-modules/intro-to-R-tidyverse/02-intro_to_tidyverse.nb.html)      |
+| 11:45       | Exercises Introduction: [Intro to R](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/03-intro_to_r_exercise.Rmd), [Intro to Tidyverse](https://github.com/AlexsLemonade/training-modules/blob/master/intro-to-R-tidyverse/04-intro_to_tidyverse_exercise.Rmd)      |
 | 12:30       | Lunch                                          |
-| 1:30        | Data Diagnostics w/ a Gastric Cancer Dataset: [tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html), [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) |
-| 3:00        | Break                                          |
-| 3:15        | Differential Expression Analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md), [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)               |
+| 1:30 PM     | Bulk RNA-seq I: [QC, trim, and quantification with Salmon](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/01-qc_trim_quant.md)            |
+| 2:00        | Bulk RNA-seq II: [Gene-Level Summaries with tximport](https://alexslemonade.github.io/training-modules/RNA-seq/02-gastric_cancer_tximport.nb.html) |
+| 2:45        | Break                                          |
+| 3:00        | Bulk RNA-seq III: [Exploratory Analyses](https://alexslemonade.github.io/training-modules/RNA-seq/03-gastric_cancer_exploratory.nb.html) |
+| 3:15        | Bulk RNA-seq IV: Differential Expression Analysis: [tximport](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/04-nb_cell_line_tximport.md), [Differential Expression](https://alexslemonade.github.io/training-modules/RNA-seq/05-nb_cell_line_DESeq2.nb.html)               |
 | 4:45        | Exercise Introduction: [Bulk RNA-seq](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/06-bulk_rnaseq_exercise.Rmd)                                              |
 | 5:00        | End                                            |
 |             |                                                |
@@ -31,7 +32,7 @@
 | 3:30        | Machine Learning: [Data Preparation](https://alexslemonade.github.io/training-modules/machine-learning/01-medulloblastoma_data_prep.nb.html), [Clustering](https://alexslemonade.github.io/training-modules/machine-learning/02-medulloblastoma_clustering.nb.html), [PLIER](https://alexslemonade.github.io/training-modules/machine-learning/03-medulloblastoma_PLIER.nb.html), [Differential PLIER LVs](https://alexslemonade.github.io/training-modules/machine-learning/04-medulloblastoma_LV_differences.nb.html)  
 | 4:45        | Exercise Introduction: [Machine Learning](https://github.com/AlexsLemonade/training-modules/blob/master/machine-learning/05-machine_learning_exercise.Rmd)                                            |
 | 5:00        | End                                           |
-| 6:00        | Dinner at TBD                                 |
+| 6:00        | Dinner at [LVMar](https://lvmar.com/)        |
 |             |                                                |
 | **Day 3**   |                                                |
 | 9:00 AM     | Analyze your own data (or some stuff we have)!                         |


### PR DESCRIPTION
This closes [Issue 27 on training-admin](https://github.com/AlexsLemonade/training-admin/issues/27). 

### Changes
- Added updated image ID information on `docker-pull.md`
- Rearranged schedule to have more time for intro to R exercises. 
- Added both Intro to R exercise notebooks to the schedule.  
- Re-organized the RNA-seq modules notebooks since they got pushed by the Intro to R.
- Added LVMar for dinner.

## Pull Request Check List:
* [x] Run a linter **NA** No code here. 
* [x] Set the seed (if applicable) **NA** No code here. 
* [x] Comments and/or documentation up to date
* [x] Double check your paths **NA** No files loaded
* [x] Check headline numbering. 
* [x] Spell check any Rmd file or md file 
* [x] Restart R and run all notebooks fresh and save **NA** only markdowns
* [x] Connect the pertinent issues on ZenHub
